### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-point-to-our-own-prefix-in-CMake-metadata-on-windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -39,7 +39,7 @@ requirements:
   host:
     # TODO: giflib missing headers on windows?
     - giflib {{ giflib }}
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - libpng {{ libpng }}
     - libtiff {{ libtiff }}
     - libwebp {{ libwebp }}
@@ -47,7 +47,7 @@ requirements:
     - zlib {{ zlib }}
   run:
     - giflib    # pin through giflib run_exports
-    - jpeg      # pin through jpeg run_exports
+    - libjpeg-turbo  # pin through libjpeg-turbo run_exports
     - libpng    # pin through libpng run_exports
     - libtiff   # pin through libtiff run_exports
     - libwebp   # pin through libwebp run_exports


### PR DESCRIPTION
leptonica 1.87.0

**Destination channel:**  defaults

### Links

- [PKG-13236](https://anaconda.atlassian.net/browse/PKG-13236) 
- [Upstream repository](https://github.com/DanBloomberg/leptonica/releases/tag/1.87.0)

### Explanation of changes:
- Replace jpeg to libjpeg-turbo
- New build number


[PKG-13236]: https://anaconda.atlassian.net/browse/PKG-13236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ